### PR TITLE
Fix package.json for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "prisma db seed",
+    "seed": "prisma db seed"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.1.1",
@@ -21,6 +21,7 @@
     "prisma": "^5.12.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "sql.js": "^1.13.0",
     "stripe": "^14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove trailing comma in `scripts`
- add `sql.js` dependency for Lab component

## Testing
- `npm run build` *(fails: `Failed to fetch font Geist` due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6840a375e95c8323a91a395c34f629f4