### PR TITLE
Fix Tailwind 4 PostCSS config and webpack aliases

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,18 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   pageExtensions: ['ts', 'tsx', 'mdx'],
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      'sql.js': 'sql.js/dist/sql-wasm.js',
+    };
+    config.resolve.fallback = {
+      ...(config.resolve.fallback || {}),
+      fs: false,
+      path: false,
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- update PostCSS config for Tailwind v4
- alias sql.js for browser build and disable fs usage

## Testing
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6840a7c3434c8323913c827d0d7c8a0a