### PR TITLE
Fix Lab template typing

### DIFF
--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { Quiz } from '@/components/Quiz';
 import { AskAI } from '@/components/AskAI';
-import { Lab } from '@/components/Lab';
+import { Lab, type LabTemplate } from '@/components/Lab';
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth';
 export default async function LearnPage({ params }: { params: Promise<{ slug: string }> }) {
@@ -38,7 +38,12 @@ export default async function LearnPage({ params }: { params: Promise<{ slug: st
       <div className="mt-4">
         <AskAI />
       </div>
-      {lesson.labTemplate && <Lab template={lesson.labTemplate} onComplete={() => {}} />}
+      {lesson.labTemplate && (
+        <Lab
+          template={lesson.labTemplate as unknown as LabTemplate}
+          onComplete={() => {}}
+        />
+      )}
     </div>
   );
 }

--- a/components/Lab.tsx
+++ b/components/Lab.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 
-interface LabTemplate {
+export interface LabTemplate {
   starter?: string;
   language?: string;
 }


### PR DESCRIPTION
## Summary
- export LabTemplate from components
- import LabTemplate on lesson page
- cast lesson.labTemplate to LabTemplate before using

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch the engine file at binaries.prisma.sh - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840b02d387c8323a38a08239091b1ca