### PR TITLE
Fix Prisma client on Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "seed": "prisma db seed"


### PR DESCRIPTION
## Summary
- run `prisma generate` before `next build`

## Testing
- `npm run lint`
- `npx prisma generate` *(fails: Failed to fetch sha256 checksum)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2178f4883238012a316b3eafb40