### PR TITLE
Improve landing page and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Freemium e-learning platform for healthcare data analytics.
 ```bash
 cp .env.example .env.local
 npm install
+npm run seed  # populate initial lessons
 npm run dev
 ```
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,46 @@
 import Link from 'next/link';
 import { prisma } from '@/lib/prisma';
+import { getSession } from '@/lib/auth';
 
 export default async function Home() {
+  const session = await getSession();
   const lessons = await prisma.lesson.findMany({ orderBy: { createdAt: 'asc' } });
+  const hasLessons = lessons.length > 0;
+
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Welcome to Prax</h1>
-      <ul>
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        {lessons.map((l: any, i: number) => (
-          <li key={l.id} className="mb-2">
-            <Link href={`/learn/${l.slug}`} className="text-green-700 underline">
-              {i + 1}. {l.title}
+      <section className="bg-green-700 text-white text-center py-20 rounded mb-8">
+        <h1 className="text-4xl font-bold mb-4">Welcome to Prax</h1>
+        <p className="mb-6">Learn healthcare data analytics with bite-sized lessons.</p>
+        {session ? (
+          hasLessons && (
+            <Link href={`/learn/${lessons[0].slug}`} className="btn">
+              Start Learning
             </Link>
-          </li>
-        ))}
-      </ul>
+          )
+        ) : (
+          <Link href="/api/auth/signin" className="btn">
+            Sign in to start
+          </Link>
+        )}
+      </section>
+      {hasLessons ? (
+        <section>
+          <h2 className="text-xl font-semibold mb-4">Available Lessons</h2>
+          <ul className="space-y-2">
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+            {lessons.map((l: any, i: number) => (
+              <li key={l.id} className="mb-2">
+                <Link href={`/learn/${l.slug}`} className="text-green-700 underline">
+                  {i + 1}. {l.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <p className="text-center text-gray-600">No lessons available yet.</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance landing page with hero section and lesson list
- document seeding the database during setup

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840ca9684e08323aef71e2ef773cb2b