### PR TITLE
Add email provider settings and nodemailer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ STRIPE_WEBHOOK_SECRET=""
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 
+# Email provider settings
+EMAIL_SERVER="smtp.resend.com"
+EMAIL_FROM="Jesse Andrist <andr0476@gmail.com>"
+
 # Analytics
 NEXT_PUBLIC_GA_ID="GA-XXXXXXX"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "praxis",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^1.1.1",
         "@prisma/client": "^5.12.1",
@@ -16,10 +15,12 @@
         "lucide-react": "^0.373.0",
         "next": "15.3.3",
         "next-auth": "^4.24.5",
+        "nodemailer": "^6.9.11",
         "openai": "^4.45.0",
         "prisma": "^5.12.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "sql.js": "^1.13.0",
         "stripe": "^14.0.0"
       },
       "devDependencies": {
@@ -5844,6 +5845,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
@@ -6892,6 +6902,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+      "license": "MIT"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "sql.js": "^1.13.0",
-    "stripe": "^14.0.0"
+    "stripe": "^14.0.0",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add `EMAIL_SERVER` and `EMAIL_FROM` to `.env.example`
- include `nodemailer` dependency
- regenerate `package-lock.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc6947ac832391cca5a0489e1e3d