### PR TITLE
Add Course model and initial content

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Freemium e-learning platform for healthcare data analytics.
 ```bash
 cp .env.example .env.local
 npm install
-npm run seed  # populate initial lessons
+npm run seed  # populate initial courses and lessons
 npm run dev
 ```
 

--- a/app/courses/[slug]/page.tsx
+++ b/app/courses/[slug]/page.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import { redirect } from 'next/navigation';
+
+export default async function CoursePage({ params }: { params: { slug: string } }) {
+  const { slug } = params;
+  const course = await prisma.course.findUnique({
+    where: { slug },
+    include: { lessons: { orderBy: { createdAt: 'asc' } } },
+  });
+  if (!course) redirect('/');
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">{course.title}</h1>
+      <ul className="space-y-2 list-decimal list-inside">
+        {course.lessons.map((l, i) => (
+          <li key={l.id}>
+            <Link href={`/learn/${l.slug}`} className="text-green-700 underline">
+              {i + 1}. {l.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,11 @@ import { getSession } from '@/lib/auth';
 
 export default async function Home() {
   const session = await getSession();
-  const lessons = await prisma.lesson.findMany({ orderBy: { createdAt: 'asc' } });
-  const hasLessons = lessons.length > 0;
+  const courses = await prisma.course.findMany({
+    orderBy: { createdAt: 'asc' },
+    include: { lessons: { orderBy: { createdAt: 'asc' } } },
+  });
+  const hasCourses = courses.length > 0;
 
   return (
     <div>
@@ -13,8 +16,8 @@ export default async function Home() {
         <h1 className="text-4xl font-bold mb-4">Welcome to Prax</h1>
         <p className="mb-6">Learn healthcare data analytics with bite-sized lessons.</p>
         {session ? (
-          hasLessons && (
-            <Link href={`/learn/${lessons[0].slug}`} className="btn">
+          hasCourses && courses[0].lessons.length > 0 && (
+            <Link href={`/learn/${courses[0].lessons[0].slug}`} className="btn">
               Start Learning
             </Link>
           )
@@ -24,22 +27,21 @@ export default async function Home() {
           </Link>
         )}
       </section>
-      {hasLessons ? (
+      {hasCourses ? (
         <section>
-          <h2 className="text-xl font-semibold mb-4">Available Lessons</h2>
-          <ul className="space-y-2">
-            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-            {lessons.map((l: any, i: number) => (
-              <li key={l.id} className="mb-2">
-                <Link href={`/learn/${l.slug}`} className="text-green-700 underline">
-                  {i + 1}. {l.title}
+          <h2 className="text-xl font-semibold mb-4">Available Courses</h2>
+          <ul className="space-y-4">
+            {courses.map((c) => (
+              <li key={c.id} className="mb-2">
+                <Link href={`/courses/${c.slug}`} className="text-green-700 underline">
+                  {c.title}
                 </Link>
               </li>
             ))}
           </ul>
         </section>
       ) : (
-        <p className="text-center text-gray-600">No lessons available yet.</p>
+        <p className="text-center text-gray-600">No courses available yet.</p>
       )}
     </div>
   );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,9 +64,20 @@ model Lesson {
   quiz        Json
   labTemplate Json?
   xpReward    Int
+  courseId    String?
+  course      Course?  @relation(fields: [courseId], references: [id], onDelete: Cascade)
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
   progresses  Progress[]
+}
+
+model Course {
+  id        String   @id @default(cuid())
+  slug      String   @unique
+  title     String
+  lessons   Lesson[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Progress {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,34 +1,46 @@
 import { prisma } from '../lib/prisma';
 
 async function main() {
-  const lessons = [
-    {
-      slug: 'intro-sql',
-      title: 'Intro to SQL',
-      youtubeUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
-      quiz: { questions: [{ q: 'What does SQL stand for?', a: 0, choices: ['Structured Query Language', 'Simple Query Link'] }] },
-      xpReward: 100,
+  await prisma.course.upsert({
+    where: { slug: 'advanced-analytics-hc-sql-bq' },
+    update: {},
+    create: {
+      slug: 'advanced-analytics-hc-sql-bq',
+      title: 'Advanced Analytics in Healthcare SQL & BigQuery',
+      lessons: {
+        create: [
+          {
+            slug: 'module-1-what-is-sql',
+            title: 'Module 1 \u2013 What is SQL and Why Should I care',
+            youtubeUrl: 'https://youtu.be/3K8XMZuhg-8',
+            quiz: { questions: [] },
+            xpReward: 100,
+          },
+          {
+            slug: 'module-2-intro-healthcare-dataset',
+            title: 'Module 2 \u2013 Intro to a Healthcare Dataset',
+            youtubeUrl: 'https://youtu.be/bt3PVXmKxnw',
+            quiz: { questions: [] },
+            xpReward: 100,
+          },
+          {
+            slug: 'module-3-sql-statement-basics',
+            title: 'Module 3 \u2013 SQL Statement Basics Using Generative AI',
+            youtubeUrl: 'https://youtu.be/P9LMgEfUDsY',
+            quiz: { questions: [] },
+            xpReward: 100,
+          },
+        ],
+      },
     },
-    {
-      slug: 'joins',
-      title: 'SQL Joins',
-      youtubeUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
-      quiz: { questions: [{ q: 'Which join returns all rows?', a: 2, choices: ['INNER', 'LEFT', 'FULL'] }] },
-      xpReward: 150,
-    },
-    {
-      slug: 'agg',
-      title: 'Aggregations',
-      youtubeUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
-      quiz: { questions: [{ q: 'COUNT(*) returns?', a: 0, choices: ['number of rows', 'sum'] }] },
-      xpReward: 200,
-    },
-  ];
-  for (const l of lessons) {
-    await prisma.lesson.upsert({ where: { slug: l.slug }, update: {}, create: l });
-  }
+  });
+
   if (process.env.ADMIN_EMAIL) {
-    await prisma.user.upsert({ where: { email: process.env.ADMIN_EMAIL }, update: { role: 'admin' }, create: { email: process.env.ADMIN_EMAIL, role: 'admin' } });
+    await prisma.user.upsert({
+      where: { email: process.env.ADMIN_EMAIL },
+      update: { role: 'admin' },
+      create: { email: process.env.ADMIN_EMAIL, role: 'admin' },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add a Course model with relation to Lesson
- seed an `Advanced Analytics in Healthcare SQL & BigQuery` course with three modules
- display courses on the home page and link to a new course page
- document that seeding populates courses and lessons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840d099825883238e65bc66dc8db711