### PR TITLE
Fix Next.js param type and add dashboard page

### DIFF
--- a/app/courses/[slug]/page.tsx
+++ b/app/courses/[slug]/page.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 import { prisma } from '@/lib/prisma';
 import { redirect } from 'next/navigation';
 
-export default async function CoursePage({ params }: { params: { slug: string } }) {
-  const { slug } = params;
+export default async function CoursePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
   const course = await prisma.course.findUnique({
     where: { slug },
     include: { lessons: { orderBy: { createdAt: 'asc' } } },

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import { getSession } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { levelFromXp } from '@/lib/level';
+
+export default async function DashboardPage() {
+  const session = await getSession();
+  if (!session) redirect('/api/auth/signin');
+
+  const [progress, courses] = await Promise.all([
+    prisma.progress.findMany({
+      where: { userId: session.user.id },
+    }),
+    prisma.course.findMany({
+      orderBy: { createdAt: 'asc' },
+    }),
+  ]);
+
+  const totalXp = progress.reduce((sum, p) => sum + p.xpEarned, 0);
+  const level = levelFromXp(totalXp);
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Welcome back{session.user.name ? `, ${session.user.name}` : ''}!</h1>
+      <p className="mb-4">XP: {totalXp} (Level {level})</p>
+      <h2 className="text-lg font-semibold mb-2">Courses</h2>
+      <ul className="space-y-2">
+        {courses.map((c) => (
+          <li key={c.id}>
+            <Link href={`/courses/${c.slug}`} className="text-green-700 underline">
+              {c.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,7 @@ export default async function Home() {
             </Link>
           )
         ) : (
-          <Link href="/api/auth/signin" className="btn">
+          <Link href="/api/auth/signin?callbackUrl=/dashboard" className="btn">
             Sign in to start
           </Link>
         )}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -24,6 +24,9 @@ export const authOptions: NextAuthOptions = {
       session.user.subscribed = user.subscribed;
       return session;
     },
+    async redirect() {
+      return '/dashboard';
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- handle async params in course route
- add a dashboard after login
- redirect users to dashboard
- link to dashboard from sign-in button

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Prisma engine - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840d40bf9b08323bc5ddbf77977a4c4