### PR TITLE
Add course navigation and start button

### DIFF
--- a/app/courses/[slug]/page.tsx
+++ b/app/courses/[slug]/page.tsx
@@ -12,7 +12,7 @@ export default async function CoursePage({ params }: { params: Promise<{ slug: s
   return (
     <div>
       <h1 className="text-xl font-bold mb-4">{course.title}</h1>
-      <ul className="space-y-2 list-decimal list-inside">
+      <ul className="space-y-2 list-decimal list-inside mb-4">
         {course.lessons.map((l, i) => (
           <li key={l.id}>
             <Link href={`/learn/${l.slug}`} className="text-green-700 underline">
@@ -21,6 +21,11 @@ export default async function CoursePage({ params }: { params: Promise<{ slug: s
           </li>
         ))}
       </ul>
+      {course.lessons.length > 0 && (
+        <Link href={`/learn/${course.lessons[0].slug}`} className="btn">
+          Start Course
+        </Link>
+      )}
     </div>
   );
 }

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+
+export default async function CoursesPage() {
+  const courses = await prisma.course.findMany({
+    orderBy: { createdAt: 'asc' },
+  });
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Courses</h1>
+      {courses.length ? (
+        <ul className="space-y-2">
+          {courses.map((c) => (
+            <li key={c.id}>
+              <Link href={`/courses/${c.slug}`} className="text-green-700 underline">
+                {c.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-gray-600">No courses available yet.</p>
+      )}
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,8 +30,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <header className="p-4 border-b flex justify-between">
           <Link href="/" className="font-bold text-green-700">Prax</Link>
           <nav>
+            <Link href="/courses" className="underline mr-2">Courses</Link>
             {session ? (
-              <Link href="/api/auth/signout" className="underline mr-2">{dict.signOut}</Link>
+              <Link href="/api/auth/signout" className="underline">{dict.signOut}</Link>
             ) : (
               <Link href="/api/auth/signin" className="underline">{dict.signIn}</Link>
             )}


### PR DESCRIPTION
## Summary
- add a dedicated `Courses` page so signed-in users can see all courses
- provide a `Courses` link in the site header
- add a `Start Course` button on each course page to jump to the first lesson

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840dd9c5df08323a19ac9fed05aff45